### PR TITLE
Update links and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,3 @@
 # docker-gs-ping
 
-A simple Go server/microservice example for [Docker's Go Language Guide](https://docs.docker.com/language/golang/).
-
-Notable features:
-
-* Includes a [multi-stage `Dockerfile`](https://github.com/olliefr/docker-gs-ping/blob/main/Dockerfile.multistage).
-* Has a CI pipeline using GitHub Actions to run tests.
-* Has a CD pipeline using GitHub Actions to publish to Docker Hub.
-
-## Want _moar_?!
-
-There is a more advanced example in [olliefr/docker-gs-ping-roach](https://github.com/olliefr/docker-gs-ping-roach) using [CockroachDB](https://github.com/cockroachdb/cockroach).
-
-## Contributing
-
-This was written for an _introduction_ section of the Docker tutorial and as such it favours brevity and pedagogical clarity over robustness. 
-
-Thus, feedback is welcome, but please no nits or pedantry. Ain't nobody got time for that 🙃
-
-## License
-
-[Apache-2.0 License](LICENSE)
+A sample Go web application example for [Docker's Go language-specific guide](https://docs.docker.com/language/golang/).

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/olliefr/docker-gs-ping
+module github.com/docker/docker-gs-ping
 
 go 1.19
 


### PR DESCRIPTION
A number of links in this forked repo still referenced the original repository on my GitHub account. That repository was archived. 

This PR updates the links in the docs and the Go modules configuration to reference this repository.

- Update links in docs to point to Docker's GitHub repositories.
- Remove irrelevant information from the README. Inspired by [docker/docker-dotnet-sample](https://github.com/docker/docker-dotnet-sample).
- Update `go.mod` to point to Docker's GitHub repositories.